### PR TITLE
Implement custom error handling with BarnacleError

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -1,0 +1,449 @@
+# Error Handling in Barnacle-RS
+
+This document describes the comprehensive error handling system implemented in Barnacle-RS using the `thiserror` library with full Axum integration.
+
+## Overview
+
+Barnacle-RS provides a structured error handling system through the `BarnacleError` enum, which:
+
+- Uses `thiserror` for automatic error trait implementations
+- Implements `IntoResponse` for seamless Axum integration  
+- Provides proper HTTP status codes and headers
+- Allows consuming applications to convert errors to their own types
+- Includes comprehensive error context and metadata
+
+## Error Types
+
+### Core Error Variants
+
+```rust
+pub enum BarnacleError {
+    /// Rate limit exceeded with detailed information
+    RateLimitExceeded {
+        remaining: u32,
+        retry_after: u64,
+        limit: u32,
+    },
+
+    /// API key validation failed
+    ApiKeyValidation { reason: String },
+
+    /// Missing API key when required
+    ApiKeyMissing,
+
+    /// Invalid API key format or value
+    InvalidApiKey { key_hint: String },
+
+    /// Backend store errors (Redis, database, etc.)
+    StoreError {
+        message: String,
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// Redis-specific errors (when redis feature enabled)
+    #[cfg(feature = "redis")]
+    Redis {
+        message: String,
+        source: redis::RedisError,
+    },
+
+    /// Connection pool errors
+    ConnectionPool {
+        message: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Configuration errors
+    Configuration { message: String },
+
+    /// JSON processing errors
+    JsonError {
+        message: String,
+        source: serde_json::Error,
+    },
+
+    /// Request parsing errors
+    RequestParsing { message: String },
+
+    /// Internal server errors
+    Internal { message: String },
+
+    /// Custom errors for extending functionality
+    Custom {
+        message: String,
+        status_code: Option<StatusCode>,
+    },
+}
+```
+
+## HTTP Status Code Mapping
+
+Each error variant maps to an appropriate HTTP status code:
+
+| Error Type | HTTP Status | Description |
+|------------|-------------|-------------|
+| `RateLimitExceeded` | 429 Too Many Requests | Rate limit exceeded |
+| `ApiKeyValidation` | 401 Unauthorized | API key validation failed |
+| `ApiKeyMissing` | 401 Unauthorized | Missing required API key |
+| `InvalidApiKey` | 401 Unauthorized | Invalid API key format/value |
+| `StoreError` | 503 Service Unavailable | Backend store unavailable |
+| `Redis` | 503 Service Unavailable | Redis operation failed |
+| `ConnectionPool` | 503 Service Unavailable | Connection pool exhausted |
+| `Configuration` | 500 Internal Server Error | Configuration error |
+| `JsonError` | 400 Bad Request | JSON parsing failed |
+| `RequestParsing` | 400 Bad Request | Request format invalid |
+| `Internal` | 500 Internal Server Error | Internal server error |
+| `Custom` | Configurable | Application-specific error |
+
+## JSON Response Format
+
+All errors are automatically converted to structured JSON responses:
+
+```json
+{
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Rate limit exceeded: 0 requests remaining, retry after 60s",
+    "type": "rate_limit",
+    "details": {
+      "remaining": 0,
+      "retry_after": 60,
+      "limit": 100
+    }
+  }
+}
+```
+
+### Rate Limit Headers
+
+Rate limit errors automatically include proper HTTP headers:
+
+```
+X-RateLimit-Remaining: 0
+X-RateLimit-Limit: 100
+X-RateLimit-Reset: 60
+Retry-After: 60
+```
+
+## Creating Errors
+
+### Constructor Methods
+
+```rust
+// Rate limit error
+let error = BarnacleError::rate_limit_exceeded(0, 60, 100);
+
+// API key errors
+let error = BarnacleError::ApiKeyMissing;
+let error = BarnacleError::invalid_api_key("abc123...");
+let error = BarnacleError::api_key_validation("Key expired");
+
+// Store errors
+let error = BarnacleError::store_error("Redis connection failed");
+let error = BarnacleError::store_error_with_source("Database error", Box::new(db_error));
+
+// Configuration errors
+let error = BarnacleError::configuration_error("Invalid rate limit setting");
+
+// Custom errors
+let error = BarnacleError::custom("Application-specific error", Some(StatusCode::CONFLICT));
+
+// Internal errors
+let error = BarnacleError::internal_error("Unexpected failure");
+```
+
+### From Conversions
+
+Automatic conversions from common error types:
+
+```rust
+// From serde_json::Error
+let json_error: serde_json::Error = /* ... */;
+let barnacle_error: BarnacleError = json_error.into();
+
+// From anyhow::Error  
+let anyhow_error: anyhow::Error = /* ... */;
+let barnacle_error: BarnacleError = anyhow_error.into();
+
+// From redis::RedisError (with redis feature)
+let redis_error: redis::RedisError = /* ... */;
+let barnacle_error: BarnacleError = redis_error.into();
+
+// From deadpool_redis::PoolError (with redis feature)
+let pool_error: deadpool_redis::PoolError = /* ... */;
+let barnacle_error: BarnacleError = pool_error.into();
+```
+
+### Adding Context
+
+```rust
+let error = BarnacleError::store_error("Connection failed")
+    .with_context("During user authentication");
+```
+
+## Application Integration
+
+### Method 1: Using From Trait
+
+```rust
+use barnacle_rs::{BarnacleError, FromBarnacleError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Rate limiting error: {0}")]
+    RateLimit(#[from] BarnacleError),
+    
+    #[error("Database error: {0}")]
+    Database(String),
+    
+    // ... other variants
+}
+
+// Automatic conversion
+let app_error: AppError = barnacle_error.into();
+```
+
+### Method 2: Using FromBarnacleError Trait
+
+```rust
+use barnacle_rs::{BarnacleError, FromBarnacleError};
+
+impl FromBarnacleError<AppError> for AppError {
+    fn from_barnacle_error(error: BarnacleError) -> AppError {
+        AppError::RateLimit(error)
+    }
+}
+
+// Manual conversion
+let app_error = AppError::from_barnacle_error(barnacle_error);
+```
+
+### Method 3: Using the Convenience Macro
+
+```rust
+use barnacle_rs::impl_from_barnacle_error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Barnacle error: {0}")]
+    Barnacle(BarnacleError),
+    // ... other variants
+}
+
+impl_from_barnacle_error!(AppError, Barnacle);
+```
+
+### Method 4: Manual Pattern Matching
+
+```rust
+fn handle_barnacle_error(error: BarnacleError) -> AppError {
+    match error {
+        BarnacleError::RateLimitExceeded { remaining, retry_after, limit } => {
+            AppError::RateLimit {
+                remaining,
+                retry_after,
+                limit,
+                context: "API rate limit exceeded".to_string(),
+            }
+        },
+        BarnacleError::ApiKeyMissing => {
+            AppError::Authentication("API key required".to_string())
+        },
+        BarnacleError::InvalidApiKey { key_hint } => {
+            AppError::Authentication(format!("Invalid API key: {}", key_hint))
+        },
+        other => AppError::Internal(format!("Service error: {}", other)),
+    }
+}
+```
+
+## Axum Handler Examples
+
+### Basic Error Handling
+
+```rust
+use axum::{Json, response::Result};
+use barnacle_rs::BarnacleError;
+
+async fn handler() -> Result<Json<Value>, BarnacleError> {
+    // Your logic here
+    if some_condition {
+        return Err(BarnacleError::rate_limit_exceeded(0, 60, 100));
+    }
+    
+    Ok(Json(json!({"status": "success"})))
+}
+```
+
+### With Application Error Type
+
+```rust
+async fn handler() -> Result<Json<Value>, AppError> {
+    let result = some_barnacle_operation().await
+        .map_err(AppError::from_barnacle_error)?;
+    
+    Ok(Json(json!({"data": result})))
+}
+```
+
+### Error Conversion in Middleware
+
+```rust
+async fn error_middleware<B>(
+    req: Request<B>,
+    next: Next<B>,
+) -> Result<Response, AppError> {
+    match next.run(req).await {
+        Ok(response) => Ok(response),
+        Err(err) => {
+            // Convert any BarnacleError to AppError
+            if let Some(barnacle_err) = err.downcast_ref::<BarnacleError>() {
+                Err(AppError::from_barnacle_error(barnacle_err.clone()))
+            } else {
+                Err(AppError::Internal("Unknown error".to_string()))
+            }
+        }
+    }
+}
+```
+
+## Error Inspection Methods
+
+### Status and Metadata
+
+```rust
+let error = BarnacleError::rate_limit_exceeded(5, 30, 100);
+
+// HTTP status code
+assert_eq!(error.status_code(), StatusCode::TOO_MANY_REQUESTS);
+
+// Error code for client identification
+assert_eq!(error.error_code(), "RATE_LIMIT_EXCEEDED");
+
+// Error category
+assert_eq!(error.error_type(), "rate_limit");
+
+// Retry information
+assert!(error.is_retryable());
+assert_eq!(error.retry_after(), Some(30));
+
+// JSON representation
+let json = error.to_json_value();
+```
+
+## Best Practices
+
+### 1. Use Appropriate Error Types
+
+```rust
+// Good: Specific error for the situation
+BarnacleError::invalid_api_key(api_key)
+
+// Avoid: Generic internal error
+BarnacleError::internal_error("Key validation failed")
+```
+
+### 2. Provide Context
+
+```rust
+// Good: Context helps debugging
+BarnacleError::store_error("Redis connection failed")
+    .with_context("During user session validation")
+
+// Basic: Less context
+BarnacleError::store_error("Redis error")
+```
+
+### 3. Handle Redis Feature Compilation
+
+```rust
+#[cfg(feature = "redis")]
+fn handle_redis_error(err: redis::RedisError) -> BarnacleError {
+    BarnacleError::redis_error("Redis operation failed", err)
+}
+
+#[cfg(not(feature = "redis"))]
+fn handle_redis_error(err: SomeOtherError) -> BarnacleError {
+    BarnacleError::store_error("Backend operation failed")
+}
+```
+
+### 4. Security Considerations
+
+```rust
+// Good: Key hint for debugging, but not full key
+BarnacleError::invalid_api_key("sk_test_abc123...")
+
+// Avoid: Exposing full API key
+BarnacleError::invalid_api_key("sk_test_abc123def456ghi789")
+```
+
+## Testing
+
+### Unit Tests
+
+```rust
+#[test]
+fn test_error_properties() {
+    let error = BarnacleError::rate_limit_exceeded(5, 30, 100);
+    
+    assert_eq!(error.status_code(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(error.error_code(), "RATE_LIMIT_EXCEEDED");
+    assert!(error.is_retryable());
+    assert_eq!(error.retry_after(), Some(30));
+}
+
+#[test]
+fn test_error_context() {
+    let error = BarnacleError::store_error("Connection failed")
+        .with_context("Database operation");
+    
+    assert!(error.to_string().contains("Database operation"));
+    assert!(error.to_string().contains("Connection failed"));
+}
+```
+
+### Integration Tests
+
+```rust
+#[tokio::test]
+async fn test_error_response() {
+    let app = Router::new().route("/test", get(|| async {
+        Err::<Json<Value>, _>(BarnacleError::rate_limit_exceeded(0, 60, 100))
+    }));
+
+    let response = app
+        .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    
+    let headers = response.headers();
+    assert_eq!(headers.get("Retry-After").unwrap(), "60");
+    assert_eq!(headers.get("X-RateLimit-Remaining").unwrap(), "0");
+}
+```
+
+## Migration from anyhow::Result
+
+If you're migrating from the previous error handling:
+
+### Before
+
+```rust
+async fn reset(&self, context: &BarnacleContext) -> anyhow::Result<()> {
+    // implementation
+}
+```
+
+### After
+
+```rust
+async fn reset(&self, context: &BarnacleContext) -> Result<(), BarnacleError> {
+    // implementation with proper error conversion
+}
+```
+
+The new system provides much better error information, proper HTTP responses, and enables consuming applications to handle errors appropriately.

--- a/examples/error_integration.rs
+++ b/examples/error_integration.rs
@@ -1,0 +1,261 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use barnacle_rs::{BarnacleError, FromBarnacleError};
+use serde_json::json;
+use thiserror::Error;
+use std::collections::HashMap;
+
+/// Example of an application-specific error enum that can convert from BarnacleError
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Authentication failed: {0}")]
+    Authentication(String),
+    
+    #[error("Rate limiting error: {0}")]
+    RateLimit(#[from] BarnacleError),
+    
+    #[error("Database error: {message}")]
+    Database { message: String },
+    
+    #[error("Validation error: {0}")]
+    Validation(String),
+    
+    #[error("Internal server error: {0}")]
+    Internal(String),
+}
+
+impl AppError {
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            AppError::Authentication(_) => StatusCode::UNAUTHORIZED,
+            AppError::RateLimit(barnacle_error) => barnacle_error.status_code(),
+            AppError::Database { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            AppError::Validation(_) => StatusCode::BAD_REQUEST,
+            AppError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            AppError::Authentication(_) => "AUTH_ERROR",
+            AppError::RateLimit(barnacle_error) => barnacle_error.error_code(),
+            AppError::Database { .. } => "DATABASE_ERROR",
+            AppError::Validation(_) => "VALIDATION_ERROR",
+            AppError::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        
+        // For rate limit errors, delegate to BarnacleError's response
+        if let AppError::RateLimit(barnacle_error) = self {
+            return barnacle_error.into_response();
+        }
+        
+        let body = Json(json!({
+            "error": {
+                "code": self.error_code(),
+                "message": self.to_string(),
+                "type": "application_error"
+            }
+        }));
+
+        (status, body).into_response()
+    }
+}
+
+// Implement the FromBarnacleError trait to enable easy conversion
+impl FromBarnacleError<AppError> for AppError {
+    fn from_barnacle_error(error: BarnacleError) -> AppError {
+        AppError::RateLimit(error)
+    }
+}
+
+// Alternative: Use the macro for simpler implementation
+// barnacle_rs::impl_from_barnacle_error!(AppError, RateLimit);
+
+/// Example handler that might encounter BarnacleError
+async fn protected_handler() -> Result<Json<serde_json::Value>, AppError> {
+    // Simulate some operation that might fail with a BarnacleError
+    let result = simulate_barnacle_operation().await;
+    
+    match result {
+        Ok(data) => Ok(Json(json!({
+            "message": "Success",
+            "data": data
+        }))),
+        Err(barnacle_error) => {
+            // Convert BarnacleError to AppError
+            Err(AppError::from_barnacle_error(barnacle_error))
+        }
+    }
+}
+
+/// Example handler that demonstrates manual error conversion
+async fn manual_conversion_handler() -> Result<Json<serde_json::Value>, AppError> {
+    let result = simulate_barnacle_operation().await;
+    
+    match result {
+        Ok(data) => Ok(Json(json!({
+            "message": "Success",
+            "data": data
+        }))),
+        Err(barnacle_error) => {
+            // Manual conversion with additional context
+            match barnacle_error {
+                BarnacleError::RateLimitExceeded { remaining, retry_after, limit } => {
+                    // You could transform this into your own error type
+                    Err(AppError::RateLimit(BarnacleError::rate_limit_exceeded(
+                        remaining, retry_after, limit
+                    ).with_context("User exceeded API rate limit")))
+                },
+                BarnacleError::ApiKeyMissing => {
+                    Err(AppError::Authentication("API key is required for this endpoint".to_string()))
+                },
+                BarnacleError::InvalidApiKey { key_hint } => {
+                    Err(AppError::Authentication(format!("Invalid API key: {}", key_hint)))
+                },
+                other => {
+                    // For other errors, wrap as internal error
+                    Err(AppError::Internal(format!("Service error: {}", other)))
+                }
+            }
+        }
+    }
+}
+
+/// Example handler showing how to add context to BarnacleErrors
+async fn context_handler() -> Result<Json<serde_json::Value>, AppError> {
+    let result = simulate_barnacle_operation().await
+        .map_err(|err| err.with_context("Failed during user data processing"))?;
+    
+    Ok(Json(json!({
+        "message": "Success",
+        "data": result
+    })))
+}
+
+/// Simulate a function that returns a BarnacleError
+async fn simulate_barnacle_operation() -> Result<HashMap<String, String>, BarnacleError> {
+    // Simulate different types of errors
+    let error_type = std::env::var("SIMULATE_ERROR").unwrap_or_default();
+    
+    match error_type.as_str() {
+        "rate_limit" => Err(BarnacleError::rate_limit_exceeded(0, 60, 100)),
+        "api_key_missing" => Err(BarnacleError::ApiKeyMissing),
+        "invalid_key" => Err(BarnacleError::invalid_api_key("test_key_123")),
+        "store_error" => Err(BarnacleError::store_error("Redis connection failed")),
+        "custom" => Err(BarnacleError::custom("Custom application error", Some(StatusCode::CONFLICT))),
+        _ => {
+            let mut data = HashMap::new();
+            data.insert("key".to_string(), "value".to_string());
+            Ok(data)
+        }
+    }
+}
+
+/// Example middleware that converts BarnacleError to AppError
+async fn error_conversion_middleware<B>(
+    req: axum::extract::Request<B>,
+    next: axum::middleware::Next<B>,
+) -> Result<Response, AppError> {
+    let response = next.run(req).await;
+    
+    // If the response is an error that contains BarnacleError information,
+    // you could inspect and transform it here
+    Ok(response)
+}
+
+#[tokio::main]
+async fn main() {
+    // Initialize tracing
+    tracing_subscriber::init();
+
+    // Build the application with error handling
+    let app = Router::new()
+        .route("/protected", get(protected_handler))
+        .route("/manual", get(manual_conversion_handler))
+        .route("/context", get(context_handler))
+        .layer(axum::middleware::from_fn(error_conversion_middleware));
+
+    println!("Starting server on http://localhost:3000");
+    println!("Try the following endpoints:");
+    println!("  GET /protected - Basic error conversion");
+    println!("  GET /manual - Manual error handling");
+    println!("  GET /context - Error with context");
+    println!();
+    println!("Set SIMULATE_ERROR environment variable to test different errors:");
+    println!("  rate_limit, api_key_missing, invalid_key, store_error, custom");
+
+    // Start the server
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_error_conversion() {
+        let app = Router::new().route("/test", get(protected_handler));
+
+        // Test with successful case
+        std::env::set_var("SIMULATE_ERROR", "");
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Test with rate limit error
+        std::env::set_var("SIMULATE_ERROR", "rate_limit");
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // Test with API key missing error
+        std::env::set_var("SIMULATE_ERROR", "api_key_missing");
+        let response = app
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_barnacle_error_properties() {
+        let error = BarnacleError::rate_limit_exceeded(5, 30, 100);
+        
+        assert_eq!(error.status_code(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(error.error_code(), "RATE_LIMIT_EXCEEDED");
+        assert_eq!(error.error_type(), "rate_limit");
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after(), Some(30));
+    }
+
+    #[test]
+    fn test_error_context() {
+        let error = BarnacleError::store_error("Connection failed")
+            .with_context("Database operation");
+        
+        assert!(error.to_string().contains("Database operation"));
+        assert!(error.to_string().contains("Connection failed"));
+    }
+}

--- a/src/api_key_middleware.rs
+++ b/src/api_key_middleware.rs
@@ -1,11 +1,13 @@
 use axum::body::Body;
 use axum::extract::Request;
-use axum::http::{HeaderMap, Response, StatusCode};
+use axum::http::{HeaderMap, Response};
+use axum::response::IntoResponse;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
 
 use crate::api_key_store::ApiKeyStore;
+use crate::error::BarnacleError;
 use crate::types::{ApiKeyMiddlewareConfig, BarnacleContext, BarnacleKey};
 use crate::{BarnacleConfig, BarnacleStore};
 
@@ -118,7 +120,8 @@ where
             // Handle missing API key
             if api_key.is_none() && config.require_api_key {
                 tracing::warn!("API key missing in header: {}", config.header_name);
-                return Ok(create_unauthorized_response("API key required"));
+                let error = BarnacleError::ApiKeyMissing;
+                return Ok(error.into_response());
             }
 
             // If we have an API key, validate it
@@ -127,7 +130,8 @@ where
 
                 if !validation_result.valid {
                     tracing::warn!("Invalid API key: {}", api_key);
-                    return Ok(create_unauthorized_response("Invalid API key"));
+                    let error = BarnacleError::invalid_api_key(&api_key);
+                    return Ok(error.into_response());
                 }
 
                 // Get rate limit configuration for this key
@@ -211,37 +215,24 @@ fn extract_api_key(headers: &HeaderMap, header_name: &str) -> Option<String> {
     None
 }
 
-fn create_unauthorized_response(message: &str) -> Response<Body> {
-    Response::builder()
-        .status(StatusCode::UNAUTHORIZED)
-        .header("Content-Type", "application/json")
-        .body(Body::from(format!(r#"{{"error": "{}"}}"#, message)))
-        .unwrap()
-}
+
 
 fn create_rate_limit_response(
     result: crate::types::BarnacleResult,
     config: &BarnacleConfig,
 ) -> Response<Body> {
-    let retry_after = result.retry_after.unwrap_or(config.window);
+    let retry_after_secs = result
+        .retry_after
+        .unwrap_or(config.window)
+        .as_secs();
 
-    let mut builder = Response::builder()
-        .status(StatusCode::TOO_MANY_REQUESTS)
-        .header("Content-Type", "application/json")
-        .header("X-RateLimit-Remaining", result.remaining.to_string())
-        .header("Retry-After", retry_after.as_secs().to_string());
+    let error = BarnacleError::rate_limit_exceeded(
+        result.remaining,
+        retry_after_secs,
+        config.max_requests,
+    );
 
-    if let Some(retry_after) = result.retry_after {
-        builder = builder.header("X-RateLimit-Reset", retry_after.as_secs().to_string());
-    }
-
-    builder
-        .body(Body::from(format!(
-            r#"{{"error": "Rate limit exceeded", "retry_after": {}, "remaining": {}}}"#,
-            retry_after.as_secs(),
-            result.remaining
-        )))
-        .unwrap()
+    error.into_response()
 }
 
 async fn handle_rate_limit_reset<S>(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,405 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use thiserror::Error;
+
+/// Main error type for the Barnacle library
+#[derive(Error, Debug)]
+pub enum BarnacleError {
+    /// Rate limit exceeded error
+    #[error("Rate limit exceeded: {remaining} requests remaining, retry after {retry_after}s")]
+    RateLimitExceeded {
+        remaining: u32,
+        retry_after: u64,
+        limit: u32,
+    },
+
+    /// API key validation errors
+    #[error("API key validation failed: {reason}")]
+    ApiKeyValidation { reason: String },
+
+    /// Missing API key when required
+    #[error("API key is required but not provided")]
+    ApiKeyMissing,
+
+    /// Invalid API key format or value
+    #[error("Invalid API key: {key_hint}")]
+    InvalidApiKey { key_hint: String },
+
+    /// Store/backend related errors
+    #[error("Backend store error: {message}")]
+    StoreError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// Redis-specific errors (when Redis feature is enabled)
+    #[cfg(feature = "redis")]
+    #[error("Redis error: {message}")]
+    Redis {
+        message: String,
+        #[source]
+        source: redis::RedisError,
+    },
+
+    /// Connection pool errors
+    #[error("Connection pool error: {message}")]
+    ConnectionPool {
+        message: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Configuration errors
+    #[error("Configuration error: {message}")]
+    Configuration { message: String },
+
+    /// JSON serialization/deserialization errors
+    #[error("JSON processing error: {message}")]
+    JsonError {
+        message: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// Request parsing errors
+    #[error("Request parsing error: {message}")]
+    RequestParsing { message: String },
+
+    /// Internal server errors
+    #[error("Internal server error: {message}")]
+    Internal { message: String },
+
+    /// Custom errors for extending functionality
+    #[error("Custom error: {message}")]
+    Custom {
+        message: String,
+        status_code: Option<StatusCode>,
+    },
+}
+
+impl BarnacleError {
+    /// Create a rate limit exceeded error
+    pub fn rate_limit_exceeded(remaining: u32, retry_after: u64, limit: u32) -> Self {
+        Self::RateLimitExceeded {
+            remaining,
+            retry_after,
+            limit,
+        }
+    }
+
+    /// Create an API key validation error
+    pub fn api_key_validation<S: Into<String>>(reason: S) -> Self {
+        Self::ApiKeyValidation {
+            reason: reason.into(),
+        }
+    }
+
+    /// Create an invalid API key error with a hint (truncated key for security)
+    pub fn invalid_api_key<S: Into<String>>(key: S) -> Self {
+        let key_str = key.into();
+        let key_hint = if key_str.len() > 8 {
+            format!("{}...", &key_str[..8])
+        } else {
+            key_str
+        };
+        Self::InvalidApiKey { key_hint }
+    }
+
+    /// Create a store error
+    pub fn store_error<S: Into<String>>(message: S) -> Self {
+        Self::StoreError {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Create a store error with source
+    pub fn store_error_with_source<S: Into<String>>(
+        message: S,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    ) -> Self {
+        Self::StoreError {
+            message: message.into(),
+            source: Some(source),
+        }
+    }
+
+    /// Create a Redis error (only available with redis feature)
+    #[cfg(feature = "redis")]
+    pub fn redis_error<S: Into<String>>(message: S, source: redis::RedisError) -> Self {
+        Self::Redis {
+            message: message.into(),
+            source,
+        }
+    }
+
+    /// Create a connection pool error
+    pub fn connection_pool_error<S: Into<String>>(
+        message: S,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    ) -> Self {
+        Self::ConnectionPool {
+            message: message.into(),
+            source,
+        }
+    }
+
+    /// Create a configuration error
+    pub fn configuration_error<S: Into<String>>(message: S) -> Self {
+        Self::Configuration {
+            message: message.into(),
+        }
+    }
+
+    /// Create a JSON error
+    pub fn json_error<S: Into<String>>(message: S, source: serde_json::Error) -> Self {
+        Self::JsonError {
+            message: message.into(),
+            source,
+        }
+    }
+
+    /// Create a request parsing error
+    pub fn request_parsing_error<S: Into<String>>(message: S) -> Self {
+        Self::RequestParsing {
+            message: message.into(),
+        }
+    }
+
+    /// Create an internal server error
+    pub fn internal_error<S: Into<String>>(message: S) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    /// Create a custom error with optional status code
+    pub fn custom<S: Into<String>>(message: S, status_code: Option<StatusCode>) -> Self {
+        Self::Custom {
+            message: message.into(),
+            status_code,
+        }
+    }
+
+    /// Get the appropriate HTTP status code for this error
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            BarnacleError::RateLimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
+            BarnacleError::ApiKeyValidation { .. } => StatusCode::UNAUTHORIZED,
+            BarnacleError::ApiKeyMissing => StatusCode::UNAUTHORIZED,
+            BarnacleError::InvalidApiKey { .. } => StatusCode::UNAUTHORIZED,
+            BarnacleError::StoreError { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            #[cfg(feature = "redis")]
+            BarnacleError::Redis { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            BarnacleError::ConnectionPool { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            BarnacleError::Configuration { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            BarnacleError::JsonError { .. } => StatusCode::BAD_REQUEST,
+            BarnacleError::RequestParsing { .. } => StatusCode::BAD_REQUEST,
+            BarnacleError::Internal { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            BarnacleError::Custom { status_code, .. } => {
+                status_code.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            }
+        }
+    }
+
+    /// Check if this error should be retried
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            BarnacleError::RateLimitExceeded { .. }
+                | BarnacleError::StoreError { .. }
+                | BarnacleError::ConnectionPool { .. }
+        )
+    }
+
+    /// Get retry-after value in seconds if applicable
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            BarnacleError::RateLimitExceeded { retry_after, .. } => Some(*retry_after),
+            _ => None,
+        }
+    }
+
+    /// Convert this error into a JSON representation
+    pub fn to_json_value(&self) -> serde_json::Value {
+        let mut json = json!({
+            "error": {
+                "code": self.error_code(),
+                "message": self.to_string(),
+                "type": self.error_type(),
+            }
+        });
+
+        // Add specific fields for certain error types
+        match self {
+            BarnacleError::RateLimitExceeded {
+                remaining,
+                retry_after,
+                limit,
+            } => {
+                json["error"]["details"] = json!({
+                    "remaining": remaining,
+                    "retry_after": retry_after,
+                    "limit": limit
+                });
+            }
+            BarnacleError::Custom { .. } => {
+                // Allow custom errors to provide additional context
+                json["error"]["details"] = json!({});
+            }
+            _ => {}
+        }
+
+        json
+    }
+
+    /// Get a unique error code for this error type
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            BarnacleError::RateLimitExceeded { .. } => "RATE_LIMIT_EXCEEDED",
+            BarnacleError::ApiKeyValidation { .. } => "API_KEY_VALIDATION_FAILED",
+            BarnacleError::ApiKeyMissing => "API_KEY_MISSING",
+            BarnacleError::InvalidApiKey { .. } => "INVALID_API_KEY",
+            BarnacleError::StoreError { .. } => "STORE_ERROR",
+            #[cfg(feature = "redis")]
+            BarnacleError::Redis { .. } => "REDIS_ERROR",
+            BarnacleError::ConnectionPool { .. } => "CONNECTION_POOL_ERROR",
+            BarnacleError::Configuration { .. } => "CONFIGURATION_ERROR",
+            BarnacleError::JsonError { .. } => "JSON_ERROR",
+            BarnacleError::RequestParsing { .. } => "REQUEST_PARSING_ERROR",
+            BarnacleError::Internal { .. } => "INTERNAL_ERROR",
+            BarnacleError::Custom { .. } => "CUSTOM_ERROR",
+        }
+    }
+
+    /// Get the error type category
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            BarnacleError::RateLimitExceeded { .. } => "rate_limit",
+            BarnacleError::ApiKeyValidation { .. }
+            | BarnacleError::ApiKeyMissing
+            | BarnacleError::InvalidApiKey { .. } => "authentication",
+            BarnacleError::StoreError { .. }
+            | BarnacleError::ConnectionPool { .. } => "backend",
+            #[cfg(feature = "redis")]
+            BarnacleError::Redis { .. } => "backend",
+            BarnacleError::Configuration { .. } | BarnacleError::Internal { .. } => "server",
+            BarnacleError::JsonError { .. } | BarnacleError::RequestParsing { .. } => "client",
+            BarnacleError::Custom { .. } => "custom",
+        }
+    }
+}
+
+/// Implement IntoResponse for Axum integration
+impl IntoResponse for BarnacleError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let mut response = Json(self.to_json_value()).into_response();
+
+        // Set status code
+        *response.status_mut() = status;
+
+        // Add rate limit headers for rate limit errors
+        if let BarnacleError::RateLimitExceeded {
+            remaining,
+            retry_after,
+            limit,
+        } = &self
+        {
+            let headers = response.headers_mut();
+            headers.insert("X-RateLimit-Remaining", remaining.to_string().parse().unwrap());
+            headers.insert("X-RateLimit-Limit", limit.to_string().parse().unwrap());
+            headers.insert("Retry-After", retry_after.to_string().parse().unwrap());
+            headers.insert("X-RateLimit-Reset", retry_after.to_string().parse().unwrap());
+        }
+
+        // Add retry-after header for retryable errors
+        if let Some(retry_after) = self.retry_after() {
+            response
+                .headers_mut()
+                .insert("Retry-After", retry_after.to_string().parse().unwrap());
+        }
+
+        response
+    }
+}
+
+/// Result type alias for Barnacle operations
+pub type BarnacleResult<T> = Result<T, BarnacleError>;
+
+/// Trait for converting BarnacleError into application-specific error types
+pub trait FromBarnacleError<T>: Sized {
+    /// Convert a BarnacleError into the application's error type
+    fn from_barnacle_error(error: BarnacleError) -> T;
+}
+
+/// Helper macro for implementing FromBarnacleError
+#[macro_export]
+macro_rules! impl_from_barnacle_error {
+    ($app_error:ty, $variant:ident) => {
+        impl $crate::error::FromBarnacleError<$app_error> for $app_error {
+            fn from_barnacle_error(error: $crate::error::BarnacleError) -> $app_error {
+                <$app_error>::$variant(error)
+            }
+        }
+    };
+}
+
+/// Convert from various error types into BarnacleError
+impl From<serde_json::Error> for BarnacleError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::json_error("JSON processing failed", err)
+    }
+}
+
+impl From<anyhow::Error> for BarnacleError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::internal_error(format!("Internal error: {}", err))
+    }
+}
+
+#[cfg(feature = "redis")]
+impl From<redis::RedisError> for BarnacleError {
+    fn from(err: redis::RedisError) -> Self {
+        Self::redis_error("Redis operation failed", err)
+    }
+}
+
+#[cfg(feature = "redis")]
+impl From<deadpool_redis::PoolError> for BarnacleError {
+    fn from(err: deadpool_redis::PoolError) -> Self {
+        Self::connection_pool_error("Redis pool error", Box::new(err))
+    }
+}
+
+/// Extensions to provide additional error context
+impl BarnacleError {
+    /// Add additional context to an error
+    pub fn with_context<S: Into<String>>(mut self, context: S) -> Self {
+        let ctx = context.into();
+        match &mut self {
+            BarnacleError::StoreError { message, .. } => {
+                *message = format!("{}: {}", ctx, message);
+            }
+            BarnacleError::Internal { message } => {
+                *message = format!("{}: {}", ctx, message);
+            }
+            BarnacleError::Custom { message, .. } => {
+                *message = format!("{}: {}", ctx, message);
+            }
+            _ => {
+                // For other error types, convert to custom error with context
+                return BarnacleError::custom(
+                    format!("{}: {}", ctx, self.to_string()),
+                    Some(self.status_code()),
+                );
+            }
+        }
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 
 mod api_key_middleware;
 mod api_key_store;
+mod error;
 mod middleware;
 mod redis_store;
 mod types;
@@ -56,14 +57,18 @@ mod types;
 // Re-export key items for easier access
 pub use api_key_middleware::{create_api_key_layer, create_api_key_layer_with_config, ApiKeyLayer};
 pub use api_key_store::{ApiKeyStore, StaticApiKeyStore};
+pub use error::{BarnacleError, BarnacleResult, FromBarnacleError};
 pub use middleware::{
     create_barnacle_layer, create_barnacle_layer_for_payload, BarnacleLayer, KeyExtractable,
 };
 pub use tracing;
 pub use types::{
     ApiKeyMiddlewareConfig, ApiKeyValidationResult, BarnacleConfig, BarnacleContext, BarnacleKey,
-    BarnacleResult, ResetOnSuccess, StaticApiKeyConfig,
+    ResetOnSuccess, StaticApiKeyConfig,
 };
+
+// Re-export the legacy BarnacleResult type from types.rs for backward compatibility
+pub use types::BarnacleResult as LegacyBarnacleResult;
 
 // Redis-specific exports (only available with "redis" feature)
 #[cfg(feature = "redis")]
@@ -82,7 +87,7 @@ use async_trait::async_trait;
 pub trait BarnacleStore: Send + Sync {
     /// Increments the counter for the key and returns the current number of requests and remaining time until reset.
     async fn increment(&self, context: &BarnacleContext, config: &BarnacleConfig)
-        -> BarnacleResult;
+        -> types::BarnacleResult;
     /// Resets the counter for the key (e.g., after successful login).
-    async fn reset(&self, context: &BarnacleContext) -> anyhow::Result<()>;
+    async fn reset(&self, context: &BarnacleContext) -> Result<(), BarnacleError>;
 }

--- a/src/redis_store.rs
+++ b/src/redis_store.rs
@@ -11,6 +11,7 @@ use deadpool_redis::redis::AsyncCommands;
 use deadpool_redis::{Connection, Pool};
 
 use crate::{
+    error::BarnacleError,
     types::{BarnacleConfig, BarnacleContext, BarnacleKey, BarnacleResult},
     BarnacleStore,
 };
@@ -186,11 +187,14 @@ impl BarnacleStore for RedisBarnacleStore {
         }
     }
 
-    async fn reset(&self, context: &BarnacleContext) -> anyhow::Result<()> {
+    async fn reset(&self, context: &BarnacleContext) -> Result<(), BarnacleError> {
         let redis_key = self.inner.get_redis_key(context);
 
-        let mut conn = self.inner.get_connection().await?;
-        let _: () = conn.del(&redis_key).await?;
+        let mut conn = self.inner.get_connection().await
+            .map_err(|e| BarnacleError::connection_pool_error("Failed to get Redis connection", Box::new(e)))?;
+        
+        let _: () = conn.del(&redis_key).await
+            .map_err(|e| BarnacleError::connection_pool_error("Failed to delete key from Redis", Box::new(e)))?;
 
         Ok(())
     }


### PR DESCRIPTION
Implement a custom error handling system using `thiserror` with Axum `IntoResponse`.

This system provides structured errors with appropriate HTTP status codes and allows consuming applications to easily translate `BarnacleError` into their own specific error types.